### PR TITLE
Adds microformats2 export format

### DIFF
--- a/formats/mf2.php
+++ b/formats/mf2.php
@@ -1,0 +1,35 @@
+<?php
+
+class MF2Format implements Format {
+    public $title = 'mf2';
+    public $mime = 'text/html';
+    public $ext = 'html';
+
+    public function export( $data ) {
+        $out = '';
+        foreach( $data['objs'] as $obj ) {
+            // Skip polygons and lines since they don't have a good microformats representation
+            if( count($obj['coords']) == 1 ) {
+                foreach( $obj['coords'] as $coord ) {
+                    $out .= '<p class="h-geo">' . "\n";
+                    if( isset($obj['text']) ) {
+                        $out .= "\t" . '<span class="p-name p-summary">' . htmlspecialchars($obj['text']) . '</span>' . "\n";
+                    }
+                    $out .= "\t" . '<data class="p-latitude">' . $coord[0] . '</data>' . "\n";
+                    $out .= "\t" . '<data class="p-longitude">' . $coord[1] . '</data>' . "\n";
+                    $out .= '</p>' . "\n";
+                }
+            }
+        }
+        return $out;
+    }
+
+    public function test( $header ) {
+        return false;
+    }
+
+    public function import( $file ) {
+    }
+}
+
+$formats['mf2'] = new MF2Format();

--- a/index.php
+++ b/index.php
@@ -118,7 +118,7 @@ if( $action == 'initdb' && NEED_INIT_DB ) {
     }
 }
 
-if( isset($_REQUEST['format']) && preg_match('/^[a-z]+$/', $_REQUEST['format']) ) {
+if( isset($_REQUEST['format']) && preg_match('/^[a-z0-9]+$/', $_REQUEST['format']) ) {
     $format = $_REQUEST['format'];
     header('Access-Control-Allow-Origin: *');
     $result = export($format, $title, $bbcode, isset($scodeid) ? $scodeid : '', !isset($_REQUEST['direct']));


### PR DESCRIPTION
Adds a microformats2 export format which exports each point as an [h-geo](http://microformats.org/wiki/h-geo) entry. 

Example output:

``` html
<p class="h-geo">
    <span class="p-name p-summary">Palio</span>
    <data class="p-latitude">45.5088</data>
    <data class="p-longitude">-122.64899</data>
</p>
<p class="h-geo">
    <span class="p-name p-summary">Cellar Door Coffee</span>
    <data class="p-latitude">45.50871</data>
    <data class="p-longitude">-122.65471</data>
</p>
<p class="h-geo">
    <span class="p-name p-summary">Ford Food &amp; Drink</span>
    <data class="p-latitude">45.50481</data>
    <data class="p-longitude">-122.65499</data>
</p>
```
